### PR TITLE
Added missing “px” to pixel values

### DIFF
--- a/jquery.fixit.js
+++ b/jquery.fixit.js
@@ -67,7 +67,7 @@
 						$el.css("height", elementHeight);
 					}
 					// Add a dummy placeholder element at the place of the element so that after getting fixed, the space is not occupied by the next element.
-					$("<div id = 'remove_" + fixedElementCount + "' class='" + ($el.attr("class")) + "' style = 'width:" + (elementWidth) + ";height:" + (elementHeight) + ";opacity:0;'></div>").insertAfter($el);
+					$("<div id = 'remove_" + fixedElementCount + "' class='" + ($el.attr("class")) + "' style = 'width:" + (elementWidth) + "px;height:" + (elementHeight) + "px;opacity:0;'></div>").insertAfter($el);
 
 					if (settings.addClassAfter != null) {
 						$el.addClass(settings.addClassAfter);


### PR DESCRIPTION
The pixel values are being added but are missing the `px` so it does nothing to the display. This pull request adds the `px` to the markup to fix that.